### PR TITLE
Add ResourceDiscovery policy to COP role.

### DIFF
--- a/aws-cli/cop/create-resources.sh
+++ b/aws-cli/cop/create-resources.sh
@@ -20,7 +20,7 @@ aws iam create-policy \
 	--policy-document "file://${this_dir}/billing-policy.json"
 
 aws iam create-policy \
-	--policy-name DuckbillGroupResourceDiscoveryPolicy \
+	--policy-name DuckbillGroupResourceDiscovery \
 	--policy-document "file://${this_dir}/resourcediscovery-policy.json"
 
 aws iam attach-role-policy \
@@ -37,6 +37,6 @@ aws iam attach-role-policy \
 
 aws iam attach-role-policy \
 	--role-name DuckbillGroupRole-COP \
-	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscovery"
 
 echo "Done!"

--- a/aws-cli/cop/create-resources.sh
+++ b/aws-cli/cop/create-resources.sh
@@ -19,9 +19,13 @@ aws iam create-policy \
 	--policy-name DuckbillGroupBilling \
 	--policy-document "file://${this_dir}/billing-policy.json"
 
+aws iam create-policy \
+	--policy-name DuckbillGroupResourceDiscoveryPolicy \
+	--policy-document "file://${this_dir}/resourcediscovery-policy.json"
+
 aws iam attach-role-policy \
 	--role-name DuckbillGroupRole-COP \
-	--policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
+	--policy-arn arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
 
 aws iam attach-role-policy \
 	--role-name DuckbillGroupRole-COP \
@@ -30,5 +34,9 @@ aws iam attach-role-policy \
 aws iam attach-role-policy \
 	--role-name DuckbillGroupRole-COP \
 	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupBilling"
+
+aws iam attach-role-policy \
+	--role-name DuckbillGroupRole-COP \
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
 
 echo "Done!"

--- a/aws-cli/cop/delete-resources.sh
+++ b/aws-cli/cop/delete-resources.sh
@@ -24,13 +24,13 @@ aws iam detach-role-policy \
 
 aws iam detach-role-policy \
 	--role-name DuckbillGroupRole-COP \
-	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscovery"
 
 aws iam delete-policy \
 	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupBilling"
 
 aws iam delete-policy \
-	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscovery"
 
 aws iam delete-role \
 	--role-name DuckbillGroupRole-COP

--- a/aws-cli/cop/delete-resources.sh
+++ b/aws-cli/cop/delete-resources.sh
@@ -12,7 +12,7 @@ echo "Deleting Duckbill Group role and policies..."
 
 aws iam detach-role-policy \
 	--role-name DuckbillGroupRole-COP \
-	--policy-arn arn:aws:iam::aws:policy/ReadOnlyAccess
+	--policy-arn arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
 
 aws iam detach-role-policy \
 	--role-name DuckbillGroupRole-COP \
@@ -22,8 +22,15 @@ aws iam detach-role-policy \
 	--role-name DuckbillGroupRole-COP \
 	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupBilling"
 
+aws iam detach-role-policy \
+	--role-name DuckbillGroupRole-COP \
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
+
 aws iam delete-policy \
 	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupBilling"
+
+aws iam delete-policy \
+	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupResourceDiscoveryPolicy"
 
 aws iam delete-role \
 	--role-name DuckbillGroupRole-COP

--- a/aws-cli/cop/resourcediscovery-policy.json
+++ b/aws-cli/cop/resourcediscovery-policy.json
@@ -1,0 +1,51 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "acm:Describe*",
+                "apigateway:GET",
+                "batch:Describe*",
+                "cloudhsm:Describe*",
+                "cloudhsm:List*",
+                "cloudwatch:Describe*",
+                "codebuild:BatchGetProjects",
+                "codecommit:BatchGetRepositories",
+                "cognito-identity:Describe*",
+                "cognito-idp:Describe*",
+                "dax:Describe*",
+                "dlm:Get*",
+                "dms:Describe*",
+                "ec2:Describe*",
+                "eks:Describe*",
+                "eks:List*",
+                "elasticfilesystem:Describe*",
+                "elasticbeanstalk:ListTagsForResource",
+                "es:ListTags",
+                "fsx:Describe*",
+                "glue:Get*",
+                "health:Describe*",
+                "iam:GetRole",
+                "iam:GetUser",
+                "kafka:List*",
+                "kms:Describe*",
+                "kms:List*",
+                "lightsail:GetInstances",
+                "lightsail:GetLoadBalancers",
+                "lightsail:GetRelationalDatabases",
+                "mq:List*",
+                "redshift:Describe*",
+                "s3:GetBucket*",
+                "s3:GetReplication*",
+                "secretsmanager:ListSecrets",
+                "shield:List*",
+                "snowball:List*",
+                "sns:GetTopicAttributes",
+                "ssm:Describe*",
+                "tag:Get*"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/cloudformation/cop/duckbill-cop-iam-role.yml
+++ b/cloudformation/cop/duckbill-cop-iam-role.yml
@@ -16,9 +16,10 @@ Resources:
             Principal:
               AWS: 753095100886
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/ReadOnlyAccess
+        - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
         - arn:aws:iam::aws:policy/job-function/Billing
         - !Ref DuckbillGroupBillingPolicy
+        - !Ref DuckbillGroupResourceDiscoveryPolicy
 
   DuckbillGroupBillingPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
@@ -37,5 +38,56 @@ Resources:
               - 'glue:BatchGetJobs'
               - 'glue:ListJobs'
               - 'pricing:GetProducts'
+            Effect: Allow
+            Resource: '*'
+
+  DuckbillGroupResourceDiscoveryPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: DuckbillGroupResourceDiscovery
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - 'acm:Describe*'
+              - 'apigateway:GET'
+              - 'batch:Describe*'
+              - 'cloudhsm:Describe*'
+              - 'cloudhsm:List*'
+              - 'cloudwatch:Describe*'
+              - 'codebuild:BatchGetProjects'
+              - 'codecommit:BatchGetRepositories'
+              - 'cognito-identity:Describe*'
+              - 'cognito-idp:Describe*'
+              - 'dax:Describe*'
+              - 'dlm:Get*'
+              - 'dms:Describe*'
+              - 'ec2:Describe*'
+              - 'eks:Describe*'
+              - 'eks:List*'
+              - 'elasticfilesystem:Describe*'
+              - 'elasticbeanstalk:ListTagsForResource'
+              - 'es:ListTags'
+              - 'fsx:Describe*'
+              - 'glue:Get*'
+              - 'health:Describe*'
+              - 'iam:GetRole'
+              - 'iam:GetUser'
+              - 'kafka:List*'
+              - 'kms:Describe*'
+              - 'kms:List*'
+              - 'lightsail:GetInstances'
+              - 'lightsail:GetLoadBalancers'
+              - 'lightsail:GetRelationalDatabases'
+              - 'mq:List*'
+              - 'redshift:Describe*'
+              - 's3:GetBucket*'
+              - 's3:GetReplication*'
+              - 'secretsmanager:ListSecrets'
+              - 'shield:List*'
+              - 'snowball:List*'
+              - 'sns:GetTopicAttributes'
+              - 'ssm:Describe*'
+              - 'tag:Get*'
             Effect: Allow
             Resource: '*'

--- a/terraform/cop/duckbill-cop-iam-role.tf
+++ b/terraform/cop/duckbill-cop-iam-role.tf
@@ -56,6 +56,64 @@ resource "aws_iam_policy" "DuckbillGroupBilling_policy" {
   policy = "${data.aws_iam_policy_document.DuckbillGroupBilling_policy_document.json}"
 }
 
+# DuckbillGroupResourceDiscovery IAM Policy - a complimentary policy
+# to the actions allowed by the ViewOnlyAccess policy
+
+data "aws_iam_policy_document" "DuckbillGroupResourceDiscovery_policy_document" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "acm:Describe*",
+      "apigateway:GET",
+      "batch:Describe*",
+      "cloudhsm:Describe*",
+      "cloudhsm:List*",
+      "cloudwatch:Describe*",
+      "codebuild:BatchGetProjects",
+      "codecommit:BatchGetRepositories",
+      "cognito-identity:Describe*",
+      "cognito-idp:Describe*",
+      "dax:Describe*",
+      "dlm:Get*",
+      "dms:Describe*",
+      "ec2:Describe*",
+      "eks:Describe*",
+      "eks:List*",
+      "elasticbeanstalk:ListTagsForResource",
+      "elasticfilesystem:Describe*",
+      "es:ListTags",
+      "fsx:Describe*",
+      "glue:Get*",
+      "health:Describe*",
+      "iam:GetRole",
+      "iam:GetUser",
+      "kafka:List*",
+      "kms:Describe*",
+      "kms:List*",
+      "lightsail:GetInstances",
+      "lightsail:GetLoadBalancers",
+      "lightsail:GetRelationalDatabases",
+      "mq:List*",
+      "redshift:Describe*",
+      "s3:GetBucket*",
+      "s3:GetReplication*",
+      "secretsmanager:ListSecrets",
+      "shield:List*",
+      "snowball:List*",
+      "sns:GetTopicAttributes",
+      "ssm:Describe*",
+      "tag:Get*"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "DuckbillGroupResourceDiscovery_policy" {
+  name   = "DuckbillGroupResourceDiscovery"
+  policy = "${data.aws_iam_policy_document.DuckbillGroupResourceDiscovery_policy_document.json}"
+}
 
 # Attach IAM Policies to DuckbillGroup Role
 
@@ -69,7 +127,12 @@ resource "aws_iam_role_policy_attachment" "duckbill-attach-Billing" {
   policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
 }
 
+resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupResourceDiscovery_policy" {
+  role       = "${aws_iam_role.DuckbillGroupRole.name}"
+  policy_arn = "${aws_iam_policy.DuckbillGroupResourceDiscovery_policy.arn}"
+}
+
 resource "aws_iam_role_policy_attachment" "duckbill-attach-ReadOnlyAccess" {
   role       = "${aws_iam_role.DuckbillGroupRole.name}"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }

--- a/terraform/cop/duckbill-cop-iam-role.tf
+++ b/terraform/cop/duckbill-cop-iam-role.tf
@@ -117,7 +117,7 @@ resource "aws_iam_policy" "DuckbillGroupResourceDiscovery_policy" {
 
 # Attach IAM Policies to DuckbillGroup Role
 
-resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupBilling_policy" {
+resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupBilling" {
   role       = "${aws_iam_role.DuckbillGroupRole.name}"
   policy_arn = "${aws_iam_policy.DuckbillGroupBilling_policy.arn}"
 }
@@ -127,12 +127,12 @@ resource "aws_iam_role_policy_attachment" "duckbill-attach-Billing" {
   policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
 }
 
-resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupResourceDiscovery_policy" {
+resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupResourceDiscovery" {
   role       = "${aws_iam_role.DuckbillGroupRole.name}"
   policy_arn = "${aws_iam_policy.DuckbillGroupResourceDiscovery_policy.arn}"
 }
 
-resource "aws_iam_role_policy_attachment" "duckbill-attach-ReadOnlyAccess" {
+resource "aws_iam_role_policy_attachment" "duckbill-attach-ViewOnlyAccess" {
   role       = "${aws_iam_role.DuckbillGroupRole.name}"
   policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
 }


### PR DESCRIPTION
Now that we have the `ResourceDiscovery` role working (mostly) copacetically with the `ViewOnlyAccess` policy, I'm updating our COP role to use `ViewOnlyAccess` plus `ResourceDiscovery` instead of the `ReadOnlyAccess` policy.

I tested this locally with my toybox account for the various deployment methods (Terraform, CloudFormation, and CLI). All three worked successfully.