### PR TITLE
Add s3:GetAnalyticsConfiguration to DuckbillGroupResourceDiscovery po…

### DIFF
--- a/aws-cli/resource-discovery-policy.json
+++ b/aws-cli/resource-discovery-policy.json
@@ -37,6 +37,7 @@
                 "lightsail:GetRelationalDatabases",
                 "mq:List*",
                 "redshift:Describe*",
+                "s3:GetAnalyticsConfiguration",
                 "s3:GetBucket*",
                 "s3:GetReplication*",
                 "secretsmanager:ListSecrets",

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -98,6 +98,7 @@ Resources:
               - 'lightsail:GetRelationalDatabases'
               - 'mq:List*'
               - 'redshift:Describe*'
+              - 's3:GetAnalyticsConfiguration'
               - 's3:GetBucket*'
               - 's3:GetReplication*'
               - 'secretsmanager:ListSecrets'

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -108,6 +108,7 @@ data "aws_iam_policy_document" "DuckbillGroupResourceDiscovery_policy_document" 
       "lightsail:GetRelationalDatabases",
       "mq:List*",
       "redshift:Describe*",
+      "s3:GetAnalyticsConfiguration",
       "s3:GetBucket*",
       "s3:GetReplication*",
       "secretsmanager:ListSecrets",


### PR DESCRIPTION
…licy.

Turns out when our tooling reviews S3 Analytics configurations, it needs to be able to read the Analytics configurations. Who knew?