### PR TITLE
Revert "Force enable MFA"

### DIFF
--- a/aws-cli/assume-role-trust-policy.json
+++ b/aws-cli/assume-role-trust-policy.json
@@ -7,12 +7,7 @@
       "Principal": {
         "AWS": "arn:aws:iam::753095100886:root"
       },
-      "Action": "sts:AssumeRole",
-      "Condition": {
-        "Bool": {
-          "aws:MultiFactorAuthPresent": "true"
-        }
-      }
+      "Action": "sts:AssumeRole"
     }
   ]
 }

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -31,9 +31,6 @@ Resources:
             Action: 'sts:AssumeRole'
             Principal:
               AWS: 753095100886
-            Condition:
-              Bool:
-                aws:MultiFactorAuthPresent: true
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
         - arn:aws:iam::aws:policy/job-function/Billing

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -32,11 +32,6 @@ data "aws_iam_policy_document" "DuckbillGroup_AssumeRole_policy_document" {
       type        = "AWS"
       identifiers = ["753095100886"]
     }
-    condition {
-      test     = "Bool"
-      variable = "aws:MultiFactorAuthPresent"
-      values   = ["true"]
-    }
   }
 }
 


### PR DESCRIPTION
Reverts DuckbillGroup/onboarding#10

In order for the CUR ingestion pipeline to work we can't force MFA enabled.