### PR TITLE
Add iam:GetPolicyVersion.

### DIFF
--- a/aws-cli/resource-discovery-policy.json
+++ b/aws-cli/resource-discovery-policy.json
@@ -27,6 +27,7 @@
                 "fsx:Describe*",
                 "glue:Get*",
                 "health:Describe*",
+                "iam:GetPolicyVersion",
                 "iam:GetRole",
                 "iam:GetUser",
                 "kafka:List*",

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -88,6 +88,7 @@ Resources:
               - 'fsx:Describe*'
               - 'glue:Get*'
               - 'health:Describe*'
+              - 'iam:GetPolicyVersion'
               - 'iam:GetRole'
               - 'iam:GetUser'
               - 'kafka:List*'

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -98,6 +98,7 @@ data "aws_iam_policy_document" "DuckbillGroupResourceDiscovery_policy_document" 
       "fsx:Describe*",
       "glue:Get*",
       "health:Describe*",
+      "iam:GetPolicyVersion",
       "iam:GetRole",
       "iam:GetUser",
       "kafka:List*",


### PR DESCRIPTION
In order for us to troubleshoot account access problems, we need to be able to view our own IAM role and the policies attached to it. We already have access to view our role, but this adds the ability to view the details of the policies attached to our role.

(I tested this in our sandbox account.)