### PR TITLE
Add SP permissions policy.

### DIFF
--- a/aws-cli/create-resources.sh
+++ b/aws-cli/create-resources.sh
@@ -67,6 +67,10 @@ aws iam attach-role-policy \
 
 aws iam attach-role-policy \
 	--role-name DuckbillGroupRole \
+	--policy-arn arn:aws:iam::aws:policy/AWSSavingsPlansReadOnlyAccess
+
+aws iam attach-role-policy \
+	--role-name DuckbillGroupRole \
 	--policy-arn "arn:aws:iam::${account_number}:policy/DuckbillGroupBilling"
 
 aws iam attach-role-policy \

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -42,6 +42,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/job-function/ViewOnlyAccess
         - arn:aws:iam::aws:policy/job-function/Billing
+        - arn:aws:iam::aws:policy/AWSSavingsPlansReadOnlyAccess
         - !Ref DuckbillGroupBillingPolicy
         - !Ref DuckbillGroupResourceDiscoveryPolicy
         - !Ref DuckbillGroupCURIngestPipelinePolicy

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -208,6 +208,11 @@ resource "aws_iam_role_policy_attachment" "duckbill-attach-Billing" {
   policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"
 }
 
+resource "aws_iam_role_policy_attachment" "duckbill-attach-SavingsPlans" {
+  role       = aws_iam_role.DuckbillGroupRole.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSavingsPlansReadOnlyAccess"
+}
+
 resource "aws_iam_role_policy_attachment" "duckbill-attach-DuckbillGroupBilling" {
   role       = aws_iam_role.DuckbillGroupRole.name
   policy_arn = aws_iam_policy.DuckbillGroupBilling_policy.arn


### PR DESCRIPTION
We get this annoying permissions error when we try to load the Savings Plans inventory for any of our clients. Adding this managed policy should fix that.

Permissions from AWS here: https://docs.aws.amazon.com/savingsplans/latest/userguide/identity-access-management.html