### PR TITLE
Add "GetStorageLensConfiguration" action.

### DIFF
--- a/aws-cli/resource-discovery-policy.json
+++ b/aws-cli/resource-discovery-policy.json
@@ -57,6 +57,7 @@
                 "s3:GetBucket*",
                 "s3:GetReplication*",
                 "s3:GetStorageLensDashboard",
+                "s3:GetStorageLensConfiguration",
                 "s3:ListStorageLensConfigurations",
                 "secretsmanager:ListSecrets",
                 "shield:List*",

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -127,6 +127,7 @@ Resources:
               - 's3:GetBucket*'
               - 's3:GetReplication*'
               - 's3:GetStorageLensDashboard'
+              - 's3:GetStorageLensConfiguration'
               - 's3:ListStorageLensConfigurations'
               - 'secretsmanager:ListSecrets'
               - 'shield:List*'

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "DuckbillGroupResourceDiscovery_policy_document" 
       "s3:GetBucket*",
       "s3:GetReplication*",
       "s3:GetStorageLensDashboard",
+      "s3:GetStorageLensConfiguration",
       "s3:ListStorageLensConfigurations",
       "secretsmanager:ListSecrets",
       "shield:List*",


### PR DESCRIPTION
Apparently we had 2 of 3 necessary S3 Storage Lens-related actions. This adds the third ("GetStorageLensConfiguration").