### PR TITLE
Update external ID step

### DIFF
--- a/aws-cli/README.md
+++ b/aws-cli/README.md
@@ -20,7 +20,7 @@ The script will prompt you for a couple of required parameters:
 
 *CUR S3 Bucket Name:* The name of the S3 bucket in which you are storing Cost and Usage Reports. If you haven't set up Cost and Usage reports in your master payer account yet, talk to us before applying this role.
 
-*External ID:* The External ID used when Duckbill assumes the role. Duckbill will provide you with a unique UUID in the onboarding documents to use for this field.
+*External ID:* The External ID used when Duckbill assumes the role. You can define this as whatever you want, though we generally recommend a UUID.
 
 ## Deleting Resources
 

--- a/cloudformation/README.md
+++ b/cloudformation/README.md
@@ -18,7 +18,7 @@ This stack includes a couple of required parameters, which you'll need to provid
 
 `CURBucketName`: The name of the S3 bucket in which you are storing Cost and Usage Reports. If you haven't set up Cost and Usage reports in your master payer account yet, talk to us before applying this role.
 
-`ExternalID`: The External ID used when Duckbill assumes the role. Duckbill will provide you with a unique UUID in the onboarding documents to use for this field.
+`ExternalID`: The External ID used when Duckbill assumes the role. You can define this as whatever you want, though we generally recommend a UUID.
 
 You can accept all the default options, or you can adjust the stack options per your company policies or preferences.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,7 +22,7 @@ Terraform will prompt you for a couple of required variables:
 
 `cur_bucket_name`: The name of the S3 bucket in which you are storing Cost and Usage Reports configured in the previous onboarding step. If you haven't set up Cost and Usage reports in your master payer account yet, talk to us before applying this role.
 
-`external_id`: The External ID used when Duckbill assumes the role. Duckbill will provide you with a unique UUID in the onboarding documents to use for this field.
+`external_id`: The External ID used when Duckbill assumes the role. You can define this as whatever you want, though we generally recommend a UUID.
 
 You'll be prompted to confirm the `apply` action.
 


### PR DESCRIPTION
We previously required Duckbill Group supply the client with an `External ID`. However, that's only necessary for clients who outright request it. In the majority of cases, the client can define their own `External ID` and share it with us.