### PR TITLE
Require terraform 0.13 or newer.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,4 +1,4 @@
-MIN_TERRAFORM_VERSION := 0.12
+MIN_TERRAFORM_VERSION := 0.13
 
 TERRAFORM_VERSION := $$(terraform -version | grep "^Terraform v" | cut -dv -f2)
 
@@ -11,7 +11,7 @@ terraform-version: cmd-exists-terraform
 		(echo "ERROR: Terraform $(MIN_TERRAFORM_VERSION) or newer is required. Found $(TERRAFORM_VERSION)"; exit 1)
 
 init: terraform-version
-	@[ -d .terraform ] || terraform init
+	@terraform init
 
 plan: init
 	@terraform plan -out terraform.tfplan

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -5,7 +5,7 @@
 
 variable "customer_name_slug" {
   type        = string
-  description = "A short, lower-case slug that identifies your company, e.g. 'acme-corp'. Duckbill Group will need to know this value, so that we can set up our own infrastructure for you."
+  description = "A short, lower-case slug that identifies your company, e.g. 'acme-corp'. Duckbill Group provided this to you in the Client Onboarding Guide."
 }
 
 variable "cur_bucket_name" {
@@ -15,15 +15,23 @@ variable "cur_bucket_name" {
 
 variable "external_id" {
   type        = string
-  description = "Customer Specific External ID string"
+  description = "The External ID used when Duckbill assumes the role. Duckbill Group provided this to you in the Client Onboarding Guide."
 }
 
 
-# Providers
+# Terraform configuration
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}
 
 provider "aws" {
-  region  = "us-east-1"
-  version = "~> 2.53"
+  region = "us-east-1"
 }
 
 
@@ -41,7 +49,7 @@ data "aws_iam_policy_document" "DuckbillGroup_AssumeRole_policy_document" {
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
-      values   = ["${var.external_id}"]
+      values   = [var.external_id]
     }
   }
 }


### PR DESCRIPTION
Terraform configuration and provider syntax changed between `0.12` and `0.13` and has remained stable since then. We can support terraform `0.13` to current.

- Upgrade terraform for `>= 0.13` syntax.
- Always initialize terraform before planning so that providers are configured correctly.
- Port some prior language changes from the README into the variable prompts.