### PR TITLE
Add internal customer ID

### DIFF
--- a/aws-cli/create-resources.sh
+++ b/aws-cli/create-resources.sh
@@ -32,7 +32,9 @@ Please enter the External ID provided to you by Duckbill Cloud Economists
 EOM
 read -rp 'External ID: ' external_id
 
-sed "s/CUSTOMER_NAME_SLUG/${customer_name_slug}/g;s/CUR_BUCKET_NAME/${cur_bucket_name}/g" \
+internal_customer_id=$(echo "${external_id}" | awk -F '-' '{print $1}' | tr -d '\r\n')
+
+sed "s/CUSTOMER_NAME_SLUG/${customer_name_slug}/g;s/CUR_BUCKET_NAME/${cur_bucket_name}/g;s/INTERNAL_CUSTOMER_ID/${internal_customer_id}/g" \
 	"${this_dir}/cur-ingest-pipeline-policy.json.template" > "${this_dir}/cur-ingest-pipeline-policy.json"
 
 sed "s/EXTERNAL_ID/${external_id}/g" \

--- a/aws-cli/cur-ingest-pipeline-policy.json.template
+++ b/aws-cli/cur-ingest-pipeline-policy.json.template
@@ -23,7 +23,9 @@
             ],
             "Resource": [
                 "arn:aws:s3:::dbg-cur-ingest-CUSTOMER_NAME_SLUG/*",
-                "arn:aws:s3:::dbg-cur-ingest-CUSTOMER_NAME_SLUG"
+                "arn:aws:s3:::dbg-cur-ingest-CUSTOMER_NAME_SLUG",
+                "arn:aws:s3:::dbg-cur-ingest-INTERNAL_CUSTOMER_ID/*",
+                "arn:aws:s3:::dbg-cur-ingest-INTERNAL_CUSTOMER_ID"
             ]
         }
     ]

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -162,7 +162,7 @@ Resources:
               - !Sub 'arn:aws:s3:::dbg-cur-ingest-${CustomerNameSlug}/*'
               - !Sub
                 - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}'
-                - external_id_prefix: !Select [0, !Split ['-', '${ExternalID}']]
+                - external_id_prefix: !Select [0, !Split ['-', !Sub '${ExternalID}']]
               - !Sub
                 - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}/*'
-                - external_id_prefix: !Select [0, !Split ['-', '${ExternalID}']]
+                - external_id_prefix: !Select [0, !Split ['-', !Sub '${ExternalID}']]

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -162,7 +162,7 @@ Resources:
               - !Sub 'arn:aws:s3:::dbg-cur-ingest-${CustomerNameSlug}/*'
               - !Sub
                 - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}'
-                - external_id_prefix: !Select [0, !Split ['-', 'ExternalID']]
+                - external_id_prefix: !Select [0, !Split ['-', '${ExternalID}']]
               - !Sub
                 - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}/*'
-                - external_id_prefix: !Select [0, !Split ['-', 'ExternalID']]
+                - external_id_prefix: !Select [0, !Split ['-', '${ExternalID}']]

--- a/cloudformation/duckbill-iam-role.yml
+++ b/cloudformation/duckbill-iam-role.yml
@@ -160,3 +160,9 @@ Resources:
             Resource:
               - !Sub 'arn:aws:s3:::dbg-cur-ingest-${CustomerNameSlug}'
               - !Sub 'arn:aws:s3:::dbg-cur-ingest-${CustomerNameSlug}/*'
+              - !Sub
+                - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}'
+                - external_id_prefix: !Select [0, !Split ['-', 'ExternalID']]
+              - !Sub
+                - 'arn:aws:s3:::dbg-cur-ingest-${external_id_prefix}/*'
+                - external_id_prefix: !Select [0, !Split ['-', 'ExternalID']]

--- a/terraform/duckbill-iam-role.tf
+++ b/terraform/duckbill-iam-role.tf
@@ -18,6 +18,9 @@ variable "external_id" {
   description = "The External ID used when Duckbill assumes the role. Duckbill Group provided this to you in the Client Onboarding Guide."
 }
 
+locals {
+  internal_customer_id = split("-", var.external_id)[0]
+}
 
 # Terraform configuration
 
@@ -194,7 +197,9 @@ data "aws_iam_policy_document" "DuckbillGroupCURIngestPipeline_policy_document" 
 
     resources = [
       "arn:aws:s3:::dbg-cur-ingest-${var.customer_name_slug}",
-      "arn:aws:s3:::dbg-cur-ingest-${var.customer_name_slug}/*"
+      "arn:aws:s3:::dbg-cur-ingest-${var.customer_name_slug}/*",
+      "arn:aws:s3:::dbg-cur-ingest-${local.internal_customer_id}",
+      "arn:aws:s3:::dbg-cur-ingest-${local.internal_customer_id}/*"
     ]
   }
 }


### PR DESCRIPTION
As we transition away from using customer slugs as part of CUR ingestion bucket names, this diff introduces the concept of an internal customer ID (based on the customer's randomly-generated external ID). This internal ID will eventually replace the customer slug entirely in these scripts. To err on the side of caution, I've granted access to both the old and new bucket names for now.